### PR TITLE
Fix Python CFFI error LNK2001: unresolved external symbol PyInit__…

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,12 @@
 patched by:
 Felix Schaller
 (c) felixschaller.com
-#########################################################################
+
+######################################################################### \\
+
 WARNING: this patch solves the "fix Python CFFI error LNK2001: unresolved external symbol PyInit__…" compile problem. But it yet requires an interface fpr python. For more Info see the Documention here: https://docs.python.org/3/extending/building.html and here: https://www.codeproject.com/articles/820116/embedding-python-program-in-a-c-cplusplus-code
-#########################################################################
+
+######################################################################### \\
 
 # pyrtools: tools for multi-scale image processing
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 patched by:
 Felix Schaller
 (c) felixschaller.com
-###########################################################################################################################################################
+#########################################################################
 WARNING: this patch solves the "fix Python CFFI error LNK2001: unresolved external symbol PyInit__…" compile problem. But it yet requires an interface fpr python. For more Info see the Documention here: https://docs.python.org/3/extending/building.html and here: https://www.codeproject.com/articles/820116/embedding-python-program-in-a-c-cplusplus-code
-###########################################################################################################################################################
+#########################################################################
 
 # pyrtools: tools for multi-scale image processing
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ------------------------------
-patched by:
-Felix Schaller
-(c) felixschaller.com
+patched by:\
+Felix Schaller\
+(c) 2023 felixschaller.com\
 
 ######################################################################### \\
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+------------------------------
+patched by:
+Felix Schaller
+(c) felixschaller.com
+###########################################################################################################################################################
+WARNING: this patch solves the "fix Python CFFI error LNK2001: unresolved external symbol PyInit__…" compile problem. But it yet requires an interface fpr python. For more Info see the Documention here: https://docs.python.org/3/extending/building.html and here: https://www.codeproject.com/articles/820116/embedding-python-program-in-a-c-cplusplus-code
+###########################################################################################################################################################
+
 # pyrtools: tools for multi-scale image processing
 
 [![PyPI Version](https://img.shields.io/pypi/v/pyrtools.svg)](https://pypi.org/project/pyrtools/)

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 ------------------------------
-patched by:\
-Felix Schaller\
-(c) 2023 felixschaller.com\
+patched by: \
+Felix Schaller \
+(c) 2023 felixschaller.com \
 
-######################################################################### \\
+######################################################################### \
 
 WARNING: this patch solves the "fix Python CFFI error LNK2001: unresolved external symbol PyInit__…" compile problem. But it yet requires an interface fpr python. For more Info see the Documention here: https://docs.python.org/3/extending/building.html and here: https://www.codeproject.com/articles/820116/embedding-python-program-in-a-c-cplusplus-code
 
-######################################################################### \\
+######################################################################### \
 
 # pyrtools: tools for multi-scale image processing
 

--- a/pyrtools/Windows.c
+++ b/pyrtools/Windows.c
@@ -1,0 +1,5 @@
+/**
+ * This contains hacks to get the installation on Windows working.
+ * This fixes error LNK2001: unresolved external symbol PyInit__cv_algorithms
+ */
+void PyInit_wrapConv(void) { }

--- a/pyrtools/pyramids/c/wrapper.py
+++ b/pyrtools/pyramids/c/wrapper.py
@@ -9,7 +9,7 @@ import numpy as np
 
 # the wrapConv.so file can have some system information after it from the compiler, so we just find
 # whatever it is called
-libpath = glob.glob(os.path.join(os.path.dirname(os.path.realpath(__file__)), 'wrapConv*.so'))
+libpath = glob.glob(os.path.join(os.path.dirname(os.path.realpath(__file__)), 'wrapConv*.*'))
 # print(libpath)
 
 # load the c library

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ pyrtools_version_module = importlib.util.module_from_spec(pyrtools_version_spec)
 pyrtools_version_spec.loader.exec_module(pyrtools_version_module)
 VERSION = pyrtools_version_module.version
 
+platform_src = ["pyrtools/windows.c"] if os.name == 'nt' else []
 
 setup(
     name='pyrtools',
@@ -35,7 +36,7 @@ setup(
                            sources=['pyrtools/pyramids/c/convolve.c',
                                     'pyrtools/pyramids/c/edges.c',
                                     'pyrtools/pyramids/c/wrap.c',
-                                    'pyrtools/pyramids/c/internal_pointOp.c'],
+                                    'pyrtools/pyramids/c/internal_pointOp.c'] + platform_src,
                            depends=['pyrtools/pyramids/c/convolve.h',
                                     'pyrtools/pyramids/c/internal_pointOp.h'],
                            extra_compile_args=['-fPIC', '-shared'])],


### PR DESCRIPTION
Fixed bug on Windows 
by Solution from: https://techoverflow.net/2022/01/23/how-to-fix-python-cffi-error-lnk2001-unresolved-external-symbol-pyinit__/