### PR TITLE
Readthedocs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -23,4 +23,3 @@ python:
   install:
     - method: pip
       path: .
-  system_packages: true

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -5,8 +5,6 @@ channels:
 
 dependencies:
   - sphinx
-  # fix sphinx 7 incompatibility issue
-  - 'sphinx_rtd_theme>=1.3.0rc1'
   - numpydoc
   - numpy
   - python
@@ -16,3 +14,5 @@ dependencies:
     - nbsphinx
     - nbsphinx_link
     - sphinxcontrib-apidoc
+    # fix sphinx 7 incompatibility issue
+    - 'sphinx_rtd_theme>=1.3.0rc1'

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -5,7 +5,8 @@ channels:
 
 dependencies:
   - sphinx
-  - sphinx_rtd_theme
+  # fix sphinx 7 incompatibility issue
+  - 'sphinx_rtd_theme>=1.3.0rc1'
   - numpydoc
   - numpy
   - python

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,6 @@ setup(
     install_requires=['numpy>=1.1',
                       'scipy>=0.18',
                       'matplotlib>=1.5',
-                      'Pillow>=3.4',
                       'tqdm>=4.29',
                       'requests>=2.21'],
     ext_modules=[Extension('pyrtools.pyramids.c.wrapConv',


### PR DESCRIPTION
Two small changes
- Remove `system_packages` from the readthedocs config because they're dropping support for that
- Remove `Pillow` from setup.py, because I don't think we use it.
- Sets minimum version for `sphinx_rtd_theme` for Sphinx 7 incompatibility: https://github.com/readthedocs/sphinx_rtd_theme/issues/1463