### PR TITLE
Fix typo

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,7 +46,7 @@ jobs:
         path: "./**/dist/*.tar.gz"
 
   deploy:
-    needs: [build_wheels, build-sdist]
+    needs: [build-wheels, build-sdist]
     runs-on: ubuntu-latest
     if: github.event_name == 'release' && github.event.action == 'published'
     steps:

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ and Jupyter installed.
 
 All code should be considered a beta release.  By that we mean that it is being
 actively developed and tested.  You can find unit tests in
-`TEST/unitTests.py` and run them with `python TEST/unitTests.py`.
+`TESTS/unitTests.py` and run them with `python TESTS/unitTests.py`.
 
 If you're using functions or parameters that do not have associated unit
 tests you should test this yourself to make sure the results are correct.


### PR DESCRIPTION
Small typo in `deploy.yml`: `build_wheels` -> `build-wheels`