### PR TITLE
CI Build Wheel fixes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,7 +24,7 @@ jobs:
           CIBW_SKIP: "*musllinux*"
           CIBW_ARCHS: native
           CIBW_BUILD_FRONTEND: build
-          CIBW_TEST_COMMAND: "python TESTS/unitTests.py"
+          CIBW_TEST_COMMAND: "python {project}/TESTS/unitTests.py"
 
       - name: "Upload wheel as artifact"
         uses: actions/upload-artifact@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,6 +25,9 @@ jobs:
           CIBW_ARCHS: native
           CIBW_BUILD_FRONTEND: build
           CIBW_TEST_COMMAND: "python {project}/TESTS/unitTests.py"
+          # cross-compilation for Apple Silicon:
+          # https://cibuildwheel.readthedocs.io/en/stable/faq/#how-to-cross-compile
+          CIBW_ARCHS_MACOS: x86_64 arm64
 
       - name: "Upload wheel as artifact"
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Two small changes:
- Fix failing CIBW builds: they were failing because the path for the tests were wrong (see [docs](https://cibuildwheel.readthedocs.io/en/stable/options/#test-command))
- Adds cross-compilation support (see [docs](https://cibuildwheel.readthedocs.io/en/stable/faq/#how-to-cross-compile)), which builds wheels for the new M2 Macs.