### PR TITLE
Add pyproject.toml with wheel as build-time dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
This should hopefully resolve the [issues in CI](https://github.com/LabForComputationalVision/pyrtools/actions/runs/7874148016/job/21483075178).

A lot of [other metadata](https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html) could be moved into `pyproject.toml` (package name, author, etc), but I went for the minimal change here.