### PR TITLE
Fix failing tests/notebooks by updating action versions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -30,7 +30,7 @@ If applicable, add screenshots to help explain your problem.
 
 **System (please complete the following information):**
  - OS: [e.g. Mac (with version), Ubuntu 18.04]
- - Python version [e.g. 3.7]
+ - Python version [e.g. 3.11]
  - Pyrtools version [e.g. 1.0.1]
 
 **Additional context**

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     needs: [get_notebooks]
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, '3.10']
+        python-version: [3.8, 3.9, '3.10', '3.11', '3.12']
         notebook: ${{fromJson(needs.get_notebooks.outputs.notebook)}}
       fail-fast: false
     name: Execute notebooks
@@ -53,7 +53,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.7, 3.8, 3.9, '3.10']
+        python-version: [3.8, 3.9, '3.10', '3.11', '3.12']
       fail-fast: false
     name: Run tests
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     outputs:
       notebook: ${{ steps.get-notebooks.outputs.nb }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - id: get-notebooks
         # it's weird to me, but the quotes around \n should *not* be escaped or it breaks
       run: "echo \"nb=$(ls TUTORIALS/*ipynb | jq -R -s -c 'split(\"\\n\")[:-1]')\"\
@@ -32,8 +32,8 @@ jobs:
       fail-fast: false
     name: Execute notebooks
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v4
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
         cache: pip
@@ -57,9 +57,9 @@ jobs:
       fail-fast: false
     name: Run tests
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Install Python 3
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
         cache: pip
@@ -80,7 +80,7 @@ jobs:
         # generate the xml file and move it to root dir for codecov
         coverage xml -o ../coverage.xml
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@858dd794fbb81941b6d60b0dca860878cba60fa9 # v3.1.1
+      uses: codecov/codecov-action@a079530fc142d3d288ddf76321ca0b7fe5b18df5 # v4.4.1
   all_tutorials_in_docs:
     runs-on: ubuntu-latest
     name: Check that all tutorial notebooks are included in docs
@@ -89,7 +89,7 @@ jobs:
       matrix:
         notebook: ${{fromJson(needs.get_notebooks.outputs.notebook)}}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Check for file
       shell: bash
       run: if [[ -z "$(grep ${{ matrix.notebook }} docs/tutorials/*nblink)" ]] ; then
@@ -98,7 +98,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Check that we don't have any extra nblink files
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Check same number of nblink and notebooks
       shell: bash
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
         pip install jupyter ipywidgets
         pip install "nbclient>=0.5.5"
     - name: Run notebooks
-      run: jupyter execute ${{ matrix.notebook }}.ipynb --kernel_name=python3
+      run: jupyter execute ${{ matrix.notebook }} --kernel_name=python3
   tests:
     runs-on: ${{matrix.os}}
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,8 @@ jobs:
         coverage xml -o ../coverage.xml
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@a079530fc142d3d288ddf76321ca0b7fe5b18df5 # v4.4.1
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
   all_tutorials_in_docs:
     runs-on: ubuntu-latest
     name: Check that all tutorial notebooks are included in docs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
         cache: pip
         cache-dependency-path: setup.py
     - name: Setup FFmpeg
-      uses: FedericoCarboni/setup-ffmpeg@v2
+      uses: FedericoCarboni/setup-ffmpeg@v3.1
     - name: Install dependencies
         # nbclient 0.5.5 is the first version that includes jupyter execute
       run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,60 +10,60 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: ["macos-latest", "ubuntu-latest", "windows-latest"]
+        os: [macos-latest, ubuntu-latest, windows-latest]
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
-      - name: "Build wheels"
-        uses: pypa/cibuildwheel@v2.8.1
-        env:
-          CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
-          CIBW_BUILD: cp37-* cp38-* cp39-* cp310-*
-          CIBW_SKIP: "*musllinux*"
-          CIBW_ARCHS: native
-          CIBW_BUILD_FRONTEND: build
-          CIBW_TEST_COMMAND: "python {project}/TESTS/unitTests.py"
+    - name: Build wheels
+      uses: pypa/cibuildwheel@357b80c11e6e995e6297e86386460ae84cbc5bee # v2.18.1
+      env:
+        CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
+        CIBW_BUILD: cp37-* cp38-* cp39-* cp310-*
+        CIBW_SKIP: '*musllinux*'
+        CIBW_ARCHS: native
+        CIBW_BUILD_FRONTEND: build
+        CIBW_TEST_COMMAND: python {project}/TESTS/unitTests.py
           # cross-compilation for Apple Silicon:
           # https://cibuildwheel.readthedocs.io/en/stable/faq/#how-to-cross-compile
-          CIBW_ARCHS_MACOS: x86_64 arm64
+        CIBW_ARCHS_MACOS: x86_64 arm64
 
-      - name: "Upload wheel as artifact"
-        uses: actions/upload-artifact@v4
-        with:
-          name: artifact-${{ matrix.os }}-wheel
-          path: "./**/*.whl"
+    - name: Upload wheel as artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: artifact-${{ matrix.os }}-wheel
+        path: ./**/*.whl
 
   build-sdist:
     name: Make source distribution
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - run: pipx run build --sdist
 
     - uses: actions/upload-artifact@v4
       with:
         name: artifact-source-dist
-        path: "./**/dist/*.tar.gz"
+        path: ./**/dist/*.tar.gz
 
   deploy:
     needs: [build-wheels, build-sdist]
     runs-on: ubuntu-latest
     if: github.event_name == 'release' && github.event.action == 'published'
     steps:
-      - uses: actions/checkout@v3
-      - name: Download all artifacts
-        uses: actions/download-artifact@v4
-      - name: Copy artifacts to dist/ folder
-        run: |
-          find . -name 'artifact-*' -exec unzip '{}' \;
-          mkdir -p dist/
-          find . -name '*.tar.gz' -exec mv '{}' dist/ \;
-          find . -name '*.whl' -exec mv '{}' dist/ \;
-      - name: Publish package to test pypi
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}
+    - uses: actions/checkout@v4
+    - name: Download all artifacts
+      uses: actions/download-artifact@v4
+    - name: Copy artifacts to dist/ folder
+      run: |
+        find . -name 'artifact-*' -exec unzip '{}' \;
+        mkdir -p dist/
+        find . -name '*.tar.gz' -exec mv '{}' dist/ \;
+        find . -name '*.whl' -exec mv '{}' dist/ \;
+    - name: Publish package to test pypi
+      uses: pypa/gh-action-pypi-publish@68e62d4871ad9d14a9d55f114e6ac71f0b408ec0 # v1.8.14
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_API_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![PyPI Version](https://img.shields.io/pypi/v/pyrtools.svg)](https://pypi.org/project/pyrtools/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/LabForComputationalVision/pyrtools/blob/main/LICENSE)
-![Python version](https://img.shields.io/badge/python-3.7|3.8|3.9|3.10-blue.svg)
+![Python version](https://img.shields.io/badge/python-3.8|3.9|3.10|3.11|3.12-blue.svg)
 [![Build Status](https://github.com/LabForComputationalVision/pyrtools/workflows/build/badge.svg)](https://github.com/LabForComputationalVision/pyrtools/actions?query=workflow%3Abuild)
 [![Documentation Status](https://readthedocs.org/projects/pyrtools/badge/?version=latest)](https://pyrtools.readthedocs.io/en/latest/?badge=latest)
 [![DOI](https://zenodo.org/badge/137527035.svg)](https://zenodo.org/doi/10.5281/zenodo.10161031)

--- a/TESTS/unitTests.py
+++ b/TESTS/unitTests.py
@@ -360,13 +360,13 @@ class LpyrTests(unittest.TestCase):
         pyRamp = pt.synthetic_images.ramp((200,200))
         pyPyr = pt.pyramids.LaplacianPyramid(pyRamp)
         recon = pyPyr.recon_pyr(levels=[1])
-        np.testing.assert_allclose(matPyr['recon'], recon)
+        np.testing.assert_allclose(matPyr['recon'], recon, atol=1e-6)
     def test12(self):
         matPyr = scipy.io.loadmat(op.join(matfiles_path, 'buildLpyr12.mat'))
         pyRamp = pt.synthetic_images.ramp((200,200))
         pyPyr = pt.pyramids.LaplacianPyramid(pyRamp)
         recon = pyPyr.recon_pyr(levels=[0, 2, 4])
-        np.testing.assert_allclose(matPyr['recon'], recon)
+        np.testing.assert_allclose(matPyr['recon'], recon, atol=1e-6)
 
 class WpyrTests(unittest.TestCase):
     def test0(self):

--- a/TESTS/unitTests.py
+++ b/TESTS/unitTests.py
@@ -217,7 +217,7 @@ class pointOpTests(unittest.TestCase):
         #foo = pointOp(200, 200, img, 5, filt, 0, 1, 0);
         foo = pt.pointOp(img, filt, 0, 1);
         foo = np.reshape(foo,(200,200))
-        self.assertTrue((matImg['foo'] == foo).all())
+        np.testing.assert_allclose(matImg['foo'], foo)
 
 class maxPyrHeightTests(unittest.TestCase):
     def test1(self):
@@ -336,7 +336,7 @@ class LpyrTests(unittest.TestCase):
         img = plt.imread(op.join(test_data_path, 'lenna-256x256.tif'))
         pyPyr = pt.pyramids.LaplacianPyramid(img)
         recon = pyPyr.recon_pyr()
-        self.assertTrue((matPyr['recon'] == recon).all())
+        np.testing.assert_allclose(matPyr['recon'], recon)
     def test8(self):
         matPyr = scipy.io.loadmat(op.join(matfiles_path, 'buildLpyr8.mat'))
         pyRamp = pt.synthetic_images.ramp(200)
@@ -360,13 +360,13 @@ class LpyrTests(unittest.TestCase):
         pyRamp = pt.synthetic_images.ramp((200,200))
         pyPyr = pt.pyramids.LaplacianPyramid(pyRamp)
         recon = pyPyr.recon_pyr(levels=[1])
-        self.assertTrue((matPyr['recon'] == recon).all())
+        np.testing.assert_allclose(matPyr['recon'], recon)
     def test12(self):
         matPyr = scipy.io.loadmat(op.join(matfiles_path, 'buildLpyr12.mat'))
         pyRamp = pt.synthetic_images.ramp((200,200))
         pyPyr = pt.pyramids.LaplacianPyramid(pyRamp)
         recon = pyPyr.recon_pyr(levels=[0, 2, 4])
-        self.assertTrue((matPyr['recon'] == recon).all())
+        np.testing.assert_allclose(matPyr['recon'], recon)
 
 class WpyrTests(unittest.TestCase):
     def test0(self):

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,7 +4,7 @@
 .. |license-shield| image:: https://img.shields.io/badge/license-MIT-yellow.svg
 			    :target: https://github.com/LabForComputationalVision/pyrtools/blob/main/LICENSE
 
-.. |python-version-shield| image:: https://img.shields.io/badge/python-3.7%7C3.8%7C3.9%7C3.10-blue.svg
+.. |python-version-shield| image:: https://img.shields.io/badge/python-3.8%7C3.9%7C3.10%7C3.11%7C3.12-blue.svg
 
 .. |build| image:: https://github.com/LabForComputationalVision/pyrtools/workflows/build/badge.svg
 		     :target: https://github.com/LabForComputationalVision/pyrtools/actions?query=workflow%3Abuild

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ dynamic = ["version"]
 authors = [{name="Pyrtools authors"}]
 description = "Python tools for multi-scale image processing, including Laplacian pyramids, Wavelets, and Steerable Pyramids."
 readme = "README.md"
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 classifiers = [
     "Development Status :: 4 - Beta",
     "Programming Language :: Python :: 3",


### PR DESCRIPTION
MacOS builds and notebooks were failing, and the codecov actions weren't updating. All these problems were pretty much fixed by updating github action versions to the most recent version (using [action-updater](https://github.com/vsoch/action-updater)). I was originally getting a "no python version 3.x can be found for macos-latest" error message, but updating the action versions fixed this.

As part of this, added tests for python 3.11 and 3.12 (which plenoptic supports now) and dropped tests for 3.7.

Additionally, changed some of the equality tests for the Laplacian Pyramid and pointOp with allclose. Previously, those tests were failing on the new Macs.