### PR TITLE
C issues: 

### DIFF
--- a/src/pyrtools/pyramids/c/convolve.c
+++ b/src/pyrtools/pyramids/c/convolve.c
@@ -245,6 +245,7 @@ int internal_expand(image,filt,temp,x_fdim,y_fdim,
   register int x_step, y_step;
   register image_type *image; 
   int x_start, y_start;
+  int x_stop, y_stop;
   image_type *filt; 
   int y_fdim, y_dim;
   char *edges;

--- a/src/pyrtools/pyramids/c/convolve.c
+++ b/src/pyrtools/pyramids/c/convolve.c
@@ -95,7 +95,6 @@ int internal_reduce(image, x_dim, y_dim, filt, temp, x_fdim, y_fdim,
   int y_fmid = y_fdim/2;
   int base_res_pos;
   fptr reflect = edge_function(edges);  /* look up edge-handling function */
-  int i,j;
 
   if (!reflect) return(-1);
 
@@ -262,7 +261,6 @@ int internal_expand(image,filt,temp,x_fdim,y_fdim,
   int y_fmid = y_fdim/2;
   int base_im_pos, x_im_dim = (x_stop-x_start+x_step-1)/x_step;
   fptr reflect = edge_function(edges);  /* look up edge-handling function */	 
-  int i,j;
 
   if (!reflect) return(-1);
 


### PR DESCRIPTION
In https://github.com/conda-forge/staged-recipes/pull/25506, the OSX build of pyrtools was failing because of a compilation error in the C code (which uses gcc in our deploy action here, but clang16 in the conda build). 

I installed `clang=16` from conda-forge in a new conda environment, then ran `CC=clang pip install .` in a clean version of the repo (which forced the compilation to use clang, see [setuptools docs](https://setuptools.pypa.io/en/latest/userguide/ext_modules.html#compiler-and-linker-options)), and was able to reproduce the error (if uninstalling and reinstalling, in order to try possible solutions, must also delete the `build/` directory that gets created by pip install; adding `-vvv` will cause the output to include the compilation command, also useful for debugging).

The issue was the `x_stop` and `y_stop` did not have a type declared: `parameter 'y_stop' was not declared, defaults to 'int'; ISO C99 and later do not support implicit int [-Wimplicit-int]`

I also removed unused `i,j`, which were raising a warning. There are many other warnings, largely about function definitions without prototypes, and I don't understand C well enough to fix them. Writing out these notes in case we need to come back and fix them at some point.