### PR TITLE
Bump link version from 1.0.4 -> 1.0.5

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -18,7 +18,7 @@ authors:
 - family-names: Ward
   given-names: Brian
 title: "Pyrtools: tools for multi-scale image processing"
-version: v1.0.4
+version: v1.0.5
 date-released: 2023-11-20
 doi: 10.5281/zenodo.10161031
 url: "https://github.com/LabForComputationalVision/pyrtools"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Build Status](https://github.com/LabForComputationalVision/pyrtools/workflows/build/badge.svg)](https://github.com/LabForComputationalVision/pyrtools/actions?query=workflow%3Abuild)
 [![Documentation Status](https://readthedocs.org/projects/pyrtools/badge/?version=latest)](https://pyrtools.readthedocs.io/en/latest/?badge=latest)
 [![DOI](https://zenodo.org/badge/137527035.svg)](https://zenodo.org/doi/10.5281/zenodo.10161031)
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/LabForComputationalVision/pyrtools/v1.0.4?filepath=TUTORIALS%2F)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/LabForComputationalVision/pyrtools/v1.0.5?filepath=TUTORIALS%2F)
 [![codecov](https://codecov.io/gh/LabForComputationalVision/pyrtools/branch/main/graph/badge.svg?token=Ei9TYftdYi)](https://codecov.io/gh/LabForComputationalVision/pyrtools)
 
 Briefly, the tools include:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,7 +10,7 @@
 		     :target: https://github.com/LabForComputationalVision/pyrtools/actions?query=workflow%3Abuild
 
 .. |binder| image:: https://mybinder.org/badge_logo.svg
-		    :target: https://mybinder.org/v2/gh/LabForComputationalVision/pyrtools/v1.0.4?filepath=TUTORIALS%2F
+		    :target: https://mybinder.org/v2/gh/LabForComputationalVision/pyrtools/v1.0.5?filepath=TUTORIALS%2F
 
 .. |doi| image:: https://zenodo.org/badge/137527035.svg
   :target: https://zenodo.org/doi/10.5281/zenodo.10161031

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -23,4 +23,4 @@ For more details, see the jupyter notebooks included in the
 ``TUTORIALS/`` directory, static versions of which are linked in the
 navigation sidebar. You can play around with a live version of them in
 order to test out the code before downloading on `binder
-<https://mybinder.org/v2/gh/LabForComputationalVision/pyrtools/v1.0.4?filepath=TUTORIALS%2F>`_
+<https://mybinder.org/v2/gh/LabForComputationalVision/pyrtools/v1.0.5?filepath=TUTORIALS%2F>`_


### PR DESCRIPTION
Changes binder links to 1.0.5, which I'll release right after this is merged.