### PR TITLE
updates steerpyr behavior

### DIFF
--- a/src/pyrtools/pyramids/SteerablePyramidFreq.py
+++ b/src/pyrtools/pyramids/SteerablePyramidFreq.py
@@ -33,7 +33,7 @@ class SteerablePyramidFreq(SteerablePyramidBase):
         2d image upon which to construct to the pyramid.
     height : 'auto' or `int`.
         The height of the pyramid. If 'auto', will automatically determine based on the size of
-        `image`.
+        `image`. If an int, must be non-negative. When height=0, only returns the residuals.
     order : `int`.
         The Gaussian derivative order used for the steerable filters. Default value is 3.
         Note that to achieve steerability the minimum number of orientation is `order` + 1,
@@ -95,6 +95,8 @@ class SteerablePyramidFreq(SteerablePyramidBase):
             self.num_scales = int(max_ht)
         elif height > max_ht:
             raise ValueError("Cannot build pyramid higher than %d levels." % (max_ht))
+        elif height < 0:
+            raise ValueError("Height must be a non-negative int.")
         else:
             self.num_scales = int(height)
 

--- a/src/pyrtools/pyramids/SteerablePyramidFreq.py
+++ b/src/pyrtools/pyramids/SteerablePyramidFreq.py
@@ -55,7 +55,8 @@ class SteerablePyramidFreq(SteerablePyramidBase):
         Human-readable string specifying the type of pyramid. For base class, is None.
     pyr_coeffs : `dict`
         Dictionary containing the coefficients of the pyramid. Keys are `(level, band)` tuples and
-        values are 1d or 2d numpy arrays (same number of dimensions as the input image)
+        values are 1d or 2d numpy arrays (same number of dimensions as the input image),
+        running from fine to coarse.
     pyr_size : `dict`
         Dictionary containing the sizes of the pyramid coefficients. Keys are `(level, band)`
         tuples and values are tuples.
@@ -86,7 +87,11 @@ class SteerablePyramidFreq(SteerablePyramidBase):
             warnings.warn("Reconstruction will not be perfect with odd-sized images")
 
         if self.order == 0 and self.is_complex:
-            warnings.warn("Reconstruction will not be perfect for a complex pyramid with order=0")
+            raise ValueError(
+                "Complex pyramid cannot have order=0! See "
+                "https://github.com/plenoptic-org/plenoptic/issues/326 "
+                "for an explanation."
+            )
 
         # we can't use the base class's _set_num_scales method because the max height is calculated
         # slightly differently

--- a/src/pyrtools/pyramids/SteerablePyramidFreq.py
+++ b/src/pyrtools/pyramids/SteerablePyramidFreq.py
@@ -94,12 +94,12 @@ class SteerablePyramidFreq(SteerablePyramidBase):
         if height == 'auto' or height is None:
             self.num_scales = int(max_ht)
         elif height > max_ht:
-            raise Exception("Cannot build pyramid higher than %d levels." % (max_ht))
+            raise ValueError("Cannot build pyramid higher than %d levels." % (max_ht))
         else:
             self.num_scales = int(height)
 
         if self.order > 15 or self.order < 0:
-            raise Exception("order must be an integer in the range [0,15].")
+            raise ValueError("order must be an integer in the range [0,15].")
 
         self.num_orientations = int(order + 1)
 

--- a/src/pyrtools/pyramids/pyramid.py
+++ b/src/pyrtools/pyramids/pyramid.py
@@ -96,7 +96,7 @@ class Pyramid:
         if height == 'auto':
             self.num_scales = max_ht
         elif height > max_ht:
-            raise Exception("Cannot build pyramid higher than %d levels." % (max_ht))
+            raise ValueError("Cannot build pyramid higher than %d levels." % (max_ht))
         else:
             self.num_scales = int(height)
 


### PR DESCRIPTION
Updates behavior of the `SteerablePyramidFreq` to match the implementation of plenoptic (https://github.com/plenoptic-org/plenoptic/pull/305/ and https://github.com/plenoptic-org/plenoptic/pull/306):
- warn the user about imperfect reconstructing when initializing pyramid with an odd-sized image
- raise ValueError if order=0 and is_complex=True (see https://github.com/plenoptic-org/plenoptic/issues/326).
- raise ValueError if height, order, or twidth are given incorrect values.
- raise ValueError if height is negative

Note that we don't raise such warnings for `SteerabePyramidSpace` here because the spatial-domain implementation cannot be complex, and its reconstruction is not perfect anyway (and the errors are approximately the same magnitude when using odd- or even-sized images).