### PR TITLE
corrects even/odd for steerpyr docstring

### DIFF
--- a/src/pyrtools/pyramids/SteerablePyramidFreq.py
+++ b/src/pyrtools/pyramids/SteerablePyramidFreq.py
@@ -42,8 +42,8 @@ class SteerablePyramidFreq(SteerablePyramidBase):
         The width of the transition region of the radial lowpass function, in octaves
     is_complex : `bool`
         Whether the pyramid coefficients should be complex or not. If True, the real and imaginary
-        parts correspond to a pair of even and odd symmetric filters. If False, the coefficients
-        only include the real part / even symmetric filter.
+        parts correspond to a pair of odd and even symmetric filters. If False, the coefficients
+        only include the real part / odd symmetric filter.
 
     Attributes
     ----------


### PR DESCRIPTION
@Bichidian noticed that they were swapped.