### PR TITLE
fix API doc

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -37,7 +37,7 @@ extensions = [
     'numpydoc',
     'nbsphinx',
     'nbsphinx_link',
-    'sphinxcontrib.apidoc',
+    "sphinx.ext.autodoc",
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -37,7 +37,7 @@ extensions = [
     'numpydoc',
     'nbsphinx',
     'nbsphinx_link',
-    "sphinx.ext.autodoc",
+    'sphinxcontrib.apidoc',
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -205,4 +205,4 @@ epub_exclude_files = ['search.html']
 
 
 # -- Extension configuration -------------------------------------------------
-apidoc_module_dir = "../pyrtools"
+apidoc_module_dir = "../src/pyrtools"

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -80,7 +80,6 @@ for image processing, here are some resources to get you started:
 
    installation
    developerguide
-   api/modules
 
 .. toctree::
    :maxdepth: 2
@@ -89,3 +88,8 @@ for image processing, here are some resources to get you started:
    :numbered:
 
    tutorials/*
+
+.. toctree::
+   :caption: API Documentation
+
+   api/modules


### PR DESCRIPTION
When changing the directory structure from `pyrtools/` to `src/pyrtools` (#32), forgot to update the value of `apidoc_module_dir` in `docs/conf.py`, which meant that the API documentation was not getting built.