### PR TITLE
Update deploy action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,10 +17,10 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Build wheels
-      uses: pypa/cibuildwheel@6a41245b42fcb325223b8793746f10456ed07436 # v2.23.2
+      uses: pypa/cibuildwheel@v4.2.0
       env:
         CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
-        CIBW_BUILD: cp37-* cp38-* cp39-* cp310-*
+        CIBW_BUILD: cp39-* cp310-* cp311-* cp312-* cp313-* cp314-*
         CIBW_SKIP: '*musllinux*'
         CIBW_ARCHS: native
         CIBW_BUILD_FRONTEND: build


### PR DESCRIPTION
Updates version for action and the python versions we build against.

This was an attempt to fix the failure [from the last deploy](https://github.com/LabForComputationalVision/pyrtools/actions/runs/33560311754/job/100033127046), where the ubuntu build failed because Pillow failed to build because

>          The headers or library files could not be found for jpeg,
>          a required dependency when compiling Pillow from source.

this is confusing because the mac and windows didn't appear to build pillow from source, and the [pillow docs](https://pillow.readthedocs.io/en/latest/installation/building-from-source.html#external-libraries) just mention needing `libjpeg` for this, and it seems unlikely to me that the github ubuntu runners would've previously include libjpeg and then stopped. so tried to update the versions to see if that easy fix does it.

EDIT: Turns out, [it does not](https://github.com/LabForComputationalVision/pyrtools/actions/runs/33563673406/job/100041833325).