### PR TITLE
Change cibuildwheel build image, setup trusted publisher workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,7 +19,6 @@ jobs:
     - name: Build wheels
       uses: pypa/cibuildwheel@v4.2.0
       env:
-        CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
         CIBW_BUILD: cp39-* cp310-* cp311-* cp312-* cp313-* cp314-*
         CIBW_SKIP: '*musllinux*'
         CIBW_ARCHS: native

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: deploy
 on:
   release:
     types: [published]
-  workflow_dispatch: {}
+  workflow_dispatch:
 
 jobs:
   build-wheels:
@@ -48,12 +48,14 @@ jobs:
         name: artifact-source-dist
         path: ./**/dist/*.tar.gz
 
-  deploy:
+  publish:
+    name: Upload release to (Test) PyPI
+    environment: pypi
     needs: [build-wheels, build-sdist]
     runs-on: ubuntu-latest
-    if: github.event_name == 'release' && github.event.action == 'published'
+    permissions:
+      id-token: write # IMPORTANT: this permission is mandatory for trusted publishing
     steps:
-    - uses: actions/checkout@v4
     - name: Download all artifacts
       uses: actions/download-artifact@v4
     - name: Copy artifacts to dist/ folder
@@ -63,7 +65,10 @@ jobs:
         find . -name '*.tar.gz' -exec mv '{}' dist/ \;
         find . -name '*.whl' -exec mv '{}' dist/ \;
     - name: Publish package to test pypi
+      if: github.event_name == 'release' && github.event.action == 'published'
+      uses: pypa/gh-action-pypi-publish@v1.13.0
+    - name: Publish package to test pypi
+      if: github.event_name != 'release'
       uses: pypa/gh-action-pypi-publish@v1.13.0
       with:
-        user: __token__
-        password: ${{ secrets.PYPI_API_TOKEN }}
+        repository-url: https://test.pypi.org/legacy/


### PR DESCRIPTION
Our ubuntu build is still failing (see #52). Came across [this discussion](https://github.com/pypa/cibuildwheel/discussions/924) which suggests the issue is which manylinux image Pillow is currently supporting. Checking out the [cibuildwheel docs](https://cibuildwheel.pypa.io/en/stable/options/#linux-image), it looks like the defaults are more recent images than manylinux2014, which I was specifying. Thus, I've removed my specification of the build image, and hopefully this will work.

I've also updated the deploy.yml action to use [a trusted publisher](https://docs.pypi.org/trusted-publishers/adding-a-publisher/) instead of API keys, as that's now the recommended course of action. I also updated the file so that it will publish to test.pypi.org if the action is triggered manually, so I can test it more easily.

EDIT: [looks like](https://github.com/LabForComputationalVision/pyrtools/actions/runs/33652055225) that fixed it.